### PR TITLE
修复使用png大图时，一直显示的是缩略图，无法显示原图。

### DIFF
--- a/library/src/main/java/com/shizhefei/view/largeimage/factory/BitmapDecoderFactory.java
+++ b/library/src/main/java/com/shizhefei/view/largeimage/factory/BitmapDecoderFactory.java
@@ -1,10 +1,11 @@
 package com.shizhefei.view.largeimage.factory;
 
+import android.graphics.BitmapFactory;
 import android.graphics.BitmapRegionDecoder;
 
 import java.io.IOException;
 
 public interface BitmapDecoderFactory {
     BitmapRegionDecoder made() throws IOException;
-    int[] getImageInfo();
+    BitmapFactory.Options getImageInfo();
 }

--- a/library/src/main/java/com/shizhefei/view/largeimage/factory/FileBitmapDecoderFactory.java
+++ b/library/src/main/java/com/shizhefei/view/largeimage/factory/FileBitmapDecoderFactory.java
@@ -25,10 +25,10 @@ public class FileBitmapDecoderFactory implements BitmapDecoderFactory {
     }
 
     @Override
-    public int[] getImageInfo() {
+    public BitmapFactory.Options getImageInfo() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
         BitmapFactory.decodeFile(path, options);
-        return new int[]{options.outWidth, options.outHeight};
+        return options;
     }
 }

--- a/library/src/main/java/com/shizhefei/view/largeimage/factory/InputStreamBitmapDecoderFactory.java
+++ b/library/src/main/java/com/shizhefei/view/largeimage/factory/InputStreamBitmapDecoderFactory.java
@@ -7,8 +7,6 @@ import android.graphics.Rect;
 import java.io.IOException;
 import java.io.InputStream;
 
-import static android.R.attr.path;
-
 public class InputStreamBitmapDecoderFactory implements BitmapDecoderFactory {
     private InputStream inputStream;
 
@@ -23,10 +21,10 @@ public class InputStreamBitmapDecoderFactory implements BitmapDecoderFactory {
     }
 
     @Override
-    public int[] getImageInfo() {
+    public BitmapFactory.Options getImageInfo() {
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inJustDecodeBounds = true;
         BitmapFactory.decodeStream(inputStream, new Rect(),options);
-        return new int[]{options.outWidth, options.outHeight};
+        return options;
     }
 }


### PR DESCRIPTION
原因：如果是PNG大图调用BitmapRegionDecoder.decodeRegion()传参Bitmap.Options使用Bitmap.Config.RGB_565时，decode结果为null，使用Bitmap.Config.ARGB_8888后OK。